### PR TITLE
JSONObject's indexer performance improvement

### DIFF
--- a/SimpleJSON.cs
+++ b/SimpleJSON.cs
@@ -862,8 +862,8 @@ namespace SimpleJSON
         {
             get
             {
-                if (m_Dict.ContainsKey(aKey))
-                    return m_Dict[aKey];
+                if (m_Dict.TryGetValue(aKey, out JSONNode outJsonNode))
+                    return outJsonNode;
                 else
                     return new JSONLazyCreator(this, aKey);
             }


### PR DESCRIPTION
Changed JsonObject's indexer operator to use Dictionary.TryGetValue(key, out value) instead of checking the existence of the key by calling Dictionary.Contains(key) before returning the value.